### PR TITLE
Add trailing slash to brand link.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
                     <span class="icon-bar">&nbsp;</span>
                     <span class="icon-bar">&nbsp;</span>
                 </button>
-                <a class="navbar-brand" href="{{ site.baseurl }}"><img alt="DocNow" src="{{ site.baseurl }}/img/dn.png"></a>
+                <a class="navbar-brand" href="{{ site.baseurl }}/"><img alt="DocNow" src="{{ site.baseurl }}/img/dn.png"></a>
             </div>
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                 <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
This, or some similar solution, is needed for internal pages, like
the Advisory Board Meeting page, for the link to refer to the home page.
